### PR TITLE
D.T Home Screen - #312 - Allow Drag & Drop To Reorganize Apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ temp-*
 tmp-*
 dist/*
 dt-home.zip
+.DS_Store
+.env

--- a/resources/js/admin.js
+++ b/resources/js/admin.js
@@ -84,3 +84,337 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     })
 })
+
+/**
+ * SortableTable class for drag & drop reordering
+ */
+class SortableTable {
+    constructor(selector, config) {
+        this.table = document.querySelector(selector);
+        this.config = config;
+        this.draggedRow = null;
+        this.placeholder = null;
+        
+        if (this.table) {
+            this.init();
+        }
+    }
+    
+    init() {
+        this.addDragHandles();
+        this.bindEvents();
+        this.hideUpDownLinks();
+        console.log('SortableTable: Initialization complete');
+    }
+    
+    addDragHandles() {
+        const tbody = this.table.querySelector('tbody');
+        const thead = this.table.querySelector('thead');
+        
+        if (!tbody || !thead) return;
+        
+        // Add header column for drag handle
+        const headerRow = thead.querySelector('tr');
+        if (headerRow) {
+            const handleHeader = document.createElement('th');
+            handleHeader.style.border = '1px solid #ddd';
+            handleHeader.style.width = '40px';
+            handleHeader.style.textAlign = 'center';
+            handleHeader.textContent = '';
+            headerRow.insertBefore(handleHeader, headerRow.firstChild);
+
+        }
+        
+        // Add drag handles to each row and make rows draggable
+        const rows = tbody.querySelectorAll('tr');
+
+        
+        rows.forEach((row, index) => {
+            // Make the entire row draggable
+            row.draggable = true;
+            row.style.cursor = 'move';
+            
+            // Add drag handle cell
+            const handleCell = document.createElement('td');
+            handleCell.className = 'drag-handle';
+            handleCell.style.border = '1px solid #ddd';
+            handleCell.style.textAlign = 'center';
+            handleCell.style.cursor = 'grab';
+            handleCell.style.backgroundColor = '#f9f9f9';
+            
+            const handleIcon = document.createElement('span');
+            handleIcon.className = 'drag-icon';
+            handleIcon.style.fontSize = '14px';
+            handleIcon.style.color = '#666';
+            handleIcon.style.cursor = 'grab';
+            handleIcon.textContent = '⋮⋮';
+            
+            handleCell.appendChild(handleIcon);
+            row.insertBefore(handleCell, row.firstChild);
+            
+
+        });
+        
+
+    }
+    
+    bindEvents() {
+        const tbody = this.table.querySelector('tbody');
+        if (!tbody) return;
+        
+        tbody.addEventListener('dragstart', this.handleDragStart.bind(this));
+        tbody.addEventListener('dragover', this.handleDragOver.bind(this));
+        tbody.addEventListener('dragenter', this.handleDragEnter.bind(this));
+        tbody.addEventListener('drop', this.handleDrop.bind(this));
+        tbody.addEventListener('dragend', this.handleDragEnd.bind(this));
+    }
+    
+    handleDragStart(e) {
+        // Check if we're dragging a table row
+        if (e.target.tagName.toLowerCase() === 'tr') {
+            this.draggedRow = e.target;
+            
+            // Create placeholder
+            this.placeholder = document.createElement('tr');
+            this.placeholder.className = 'drag-placeholder';
+            this.placeholder.style.height = '2px';
+            this.placeholder.style.backgroundColor = '#007cba';
+            this.placeholder.innerHTML = '<td colspan="100%" style="height: 2px; padding: 0; border: none;"></td>';
+            
+            // Add some visual feedback to the dragged row
+            e.target.style.opacity = '0.5';
+            
+
+            e.dataTransfer.effectAllowed = 'move';
+            e.dataTransfer.setData('text/html', e.target.outerHTML);
+        } else {
+            // Prevent drag if not initiated from a row
+            e.preventDefault();
+        }
+    }
+    
+    handleDragOver(e) {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        
+        if (!this.draggedRow || !this.placeholder) return;
+        
+        const afterElement = this.getDragAfterElement(e.clientY);
+        const tbody = this.table.querySelector('tbody');
+        
+        if (!tbody) return;
+        
+        // Remove placeholder if it exists in DOM
+        if (this.placeholder.parentNode) {
+            this.placeholder.parentNode.removeChild(this.placeholder);
+        }
+        
+        // Insert placeholder
+        if (afterElement == null) {
+            tbody.appendChild(this.placeholder);
+        } else {
+            tbody.insertBefore(this.placeholder, afterElement);
+        }
+    }
+    
+    handleDragEnter(e) {
+        e.preventDefault();
+    }
+    
+    handleDrop(e) {
+        e.preventDefault();
+        
+        if (!this.draggedRow || !this.placeholder) return;
+        
+        // Get the parent of the placeholder
+        const tbody = this.placeholder.parentNode;
+        if (!tbody) return;
+        
+        // Replace placeholder with dragged row
+        tbody.insertBefore(this.draggedRow, this.placeholder);
+        tbody.removeChild(this.placeholder);
+        
+        // Reset styles
+        this.draggedRow.style.opacity = '';
+        
+
+        this.updateOrder();
+    }
+    
+    handleDragEnd(e) {
+        // Clean up
+        if (this.draggedRow) {
+            this.draggedRow.style.opacity = '';
+        }
+        
+        // Remove placeholder if it still exists
+        if (this.placeholder && this.placeholder.parentNode) {
+            this.placeholder.parentNode.removeChild(this.placeholder);
+        }
+        
+        this.draggedRow = null;
+        this.placeholder = null;
+    }
+    
+    getDragAfterElement(y) {
+        const tbody = this.table.querySelector('tbody');
+        const draggableElements = [...tbody.querySelectorAll('tr:not(.drag-placeholder)')];
+        
+        return draggableElements.reduce((closest, child) => {
+            if (child === this.draggedRow) return closest;
+            
+            const box = child.getBoundingClientRect();
+            const offset = y - box.top - box.height / 2;
+            
+            if (offset < 0 && offset > closest.offset) {
+                return { offset: offset, element: child };
+            } else {
+                return closest;
+            }
+        }, { offset: Number.NEGATIVE_INFINITY }).element;
+    }
+    
+    updateOrder() {
+        const tbody = this.table.querySelector('tbody');
+        const rows = tbody.querySelectorAll('tr:not(.drag-placeholder)');
+        const orderedIds = [];
+        rows.forEach((row, index) => {
+            if (this.config.type === 'app') {
+                // For apps, look for slug in the action links
+                const actionCell = row.cells[row.cells.length - 1]; // Last cell contains actions
+                const actionLinks = actionCell.querySelectorAll('a[href*="action="]');
+                
+                for (let link of actionLinks) {
+                    const href = link.getAttribute('href');
+                    const match = href.match(/action=\w+\/([^&]+)/);
+                    if (match) {
+                        orderedIds.push(match[1]);
+                        break;
+                    }
+                }
+            } else if (this.config.type === 'training') {
+                // For training, look for ID in the action links
+                const actionCell = row.cells[row.cells.length - 1]; // Last cell contains actions
+                const actionLinks = actionCell.querySelectorAll('a[href*="action="]');
+                
+                for (let link of actionLinks) {
+                    const href = link.getAttribute('href');
+                    const match = href.match(/action=\w+\/(\d+)/);
+                    if (match) {
+                        orderedIds.push(parseInt(match[1]));
+                        break;
+                    }
+                }
+            }
+        });
+        this.sendOrderUpdate(orderedIds);
+    }
+    
+    sendOrderUpdate(orderedIds) {
+        // Use GET request with query parameters (simpler and more reliable)
+        const params = new URLSearchParams();
+        params.append('ordered_ids', orderedIds.join(','));
+        
+        const url = `${this.config.endpoint}&${params.toString()}`;
+        
+        // Redirect to the reorder URL
+        window.location.href = url;
+    }
+    
+    showMessage(text, type) {
+        // Create or update message element
+        let messageEl = document.querySelector('.sortable-message');
+        if (!messageEl) {
+            messageEl = document.createElement('div');
+            messageEl.className = 'sortable-message';
+            messageEl.style.position = 'fixed';
+            messageEl.style.top = '20px';
+            messageEl.style.right = '20px';
+            messageEl.style.padding = '10px 20px';
+            messageEl.style.borderRadius = '4px';
+            messageEl.style.color = 'white';
+            messageEl.style.fontWeight = 'bold';
+            messageEl.style.zIndex = '9999';
+            document.body.appendChild(messageEl);
+        }
+        
+        messageEl.textContent = text;
+        messageEl.style.backgroundColor = type === 'success' ? '#46b450' : '#dc3232';
+        messageEl.style.display = 'block';
+        
+        // Auto-hide after 3 seconds
+        setTimeout(() => {
+            messageEl.style.display = 'none';
+        }, 3000);
+    }
+    
+    hideUpDownLinks() {
+        const actionCells = this.table.querySelectorAll('td:last-child');
+        actionCells.forEach(cell => {
+            const upLinks = cell.querySelectorAll('a[href*="action=up"]');
+            const downLinks = cell.querySelectorAll('a[href*="action=down"]');
+            
+            upLinks.forEach(link => {
+                link.style.display = 'none';
+                
+                // Hide the separator after the Up link
+                let nextNode = link.nextSibling;
+                while (nextNode && nextNode.nodeType === Node.TEXT_NODE) {
+                    if (nextNode.textContent.includes('|')) {
+                        nextNode.textContent = nextNode.textContent.replace(/\s*\|\s*/, '');
+                    }
+                    nextNode = nextNode.nextSibling;
+                }
+            });
+            
+            downLinks.forEach(link => {
+                link.style.display = 'none';
+                
+                // Hide the separator before the Down link
+                let prevNode = link.previousSibling;
+                while (prevNode && prevNode.nodeType === Node.TEXT_NODE) {
+                    if (prevNode.textContent.includes('|')) {
+                        prevNode.textContent = prevNode.textContent.replace(/\s*\|\s*/, '');
+                    }
+                    prevNode = prevNode.previousSibling;
+                }
+            });
+        });
+        
+
+    }
+}
+
+// DT Home Admin JavaScript
+
+document.addEventListener('DOMContentLoaded', function() {
+    // Check if we're on the dt_home admin page
+    const urlParams = new URLSearchParams(window.location.search);
+    const page = urlParams.get('page');
+    const tab = urlParams.get('tab');
+    const action = urlParams.get('action');
+    
+    // Skip drag and drop functionality when creating new apps or editing
+    if (page === 'dt_home' && (tab === 'app' || tab === 'training') && action !== 'create' && action !== 'available_app' && !action?.startsWith('edit')) {
+        // Wait a bit for the DOM to fully load
+        setTimeout(() => {
+            // Find table
+            const table = document.querySelector('.widefat');
+            
+            if (table) {
+                // Initialize sortable functionality
+                if (tab === 'app') {
+                    new SortableTable('.widefat', {
+                        type: 'app',
+                        endpoint: 'admin.php?page=dt_home&tab=app&action=reorder'
+                    });
+                } else if (tab === 'training') {
+                    new SortableTable('.widefat', {
+                        type: 'training',
+                        endpoint: 'admin.php?page=dt_home&tab=training&action=reorder'
+                    });
+                }
+            }
+        }, 100); // Close setTimeout
+    }
+});

--- a/resources/views/settings/app.php
+++ b/resources/views/settings/app.php
@@ -3,7 +3,7 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
 ?>
 
 <form method="post">
-    <?php wp_nonce_field( 'dt_admin_form', 'dt_admin_form_nonce' ) ?>
+    <?php wp_nonce_field( 'dt_admin_form_nonce' ) ?>
 
     <!-- Add a form -->
 </form>
@@ -53,12 +53,12 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
                         <tr>
                             <td style="border: 1px solid #ddd;"><?php echo esc_html( $app['name'] ); ?></td>
                             <td style="border: 1px solid #ddd;"><?php echo esc_html( $app_type_label_prefix ); ?></td>
-                            <td style="border: 1px solid #ddd;">
+                            <td style="border: 1px solid #ddd; text-align: center; padding: 8px;">
                                 <?php if ( !empty( $app['icon'] ) ) : ?>
                                     <?php if ( filter_var( $app['icon'], FILTER_VALIDATE_URL ) || strpos( $app['icon'], '/wp-content/' ) === 0 ) : ?>
-                                        <img src="<?php echo esc_url( $app['icon'] ); ?>" alt="<?php esc_attr_e( 'Icon', 'dt-home' ); ?>" style="width: 50px; height: 50px;">
+                                        <img src="<?php echo esc_url( $app['icon'] ); ?>" alt="<?php esc_attr_e( 'Icon', 'dt-home' ); ?>" style="width: 24px; height: 24px; object-fit: contain;">
                                     <?php elseif ( preg_match( '/^mdi\smdi-/', $app['icon'] ) ) : ?>
-                                        <i class="<?php echo esc_attr( $app['icon'] ); ?>" style="font-size: 50px;"></i>
+                                        <i class="<?php echo esc_attr( $app['icon'] ); ?>" style="font-size: 24px;"></i>
                                     <?php endif; ?>
                                 <?php endif; ?>
                             </td>

--- a/resources/views/settings/available-apps.php
+++ b/resources/views/settings/available-apps.php
@@ -40,12 +40,12 @@ $this->layout( 'layouts/settings', compact( 'tab', 'link', 'page_title' ) )
                         <tr>
                             <td style="border: 1px solid #ddd;"><?php echo esc_html( $app['name'] ); ?></td>
                             <td style="border: 1px solid #ddd;"><?php echo esc_html( $app['type'] ); ?></td>
-                            <td style="border: 1px solid #ddd;">
+                            <td style="border: 1px solid #ddd; text-align: center; padding: 8px;">
                                 <?php if ( !empty( $app['icon'] ) ) : ?>
                                     <?php if ( filter_var( $app['icon'], FILTER_VALIDATE_URL ) || strpos( $app['icon'], '/wp-content/' ) === 0 ) : ?>
-                                        <img src="<?php echo esc_url( $app['icon'] ); ?>" alt="<?php esc_attr_e( 'Icon', 'dt-home' ); ?>" style="width: 50px; height: 50px;">
+                                        <img src="<?php echo esc_url( $app['icon'] ); ?>" alt="<?php esc_attr_e( 'Icon', 'dt-home' ); ?>" style="width: 24px; height: 24px; object-fit: contain;">
                                     <?php elseif ( preg_match( '/^mdi\smdi-/', $app['icon'] ) ) : ?>
-                                        <i class="<?php echo esc_attr( $app['icon'] ); ?>" style="font-size: 50px;"></i>
+                                        <i class="<?php echo esc_attr( $app['icon'] ); ?>" style="font-size: 24px;"></i>
                                     <?php endif; ?>
                                 <?php endif; ?>
                             </td>

--- a/resources/views/settings/create.php
+++ b/resources/views/settings/create.php
@@ -24,6 +24,7 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
         <th><?php esc_html_e('Apps', 'dt-home') ?></th>
         <th></th>
         <th></th>
+        <th></th>
     </tr>
     </thead>
     <tbody>
@@ -33,7 +34,7 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
                 <span class="tooltiptext"><?php esc_html_e('Enter the name of the app.', 'dt-home') ?></span>
             </span>
         </td>
-        <td colspan="2">
+        <td colspan="3">
             <input style="min-width: 100%;" class="form-control" type="text" name="name" id="name" pattern=".*\S+.*" title="<?php esc_attr_e('The name cannot be empty or just whitespace.', 'dt-home'); ?>" required/>
         </td>
     </tr>
@@ -43,7 +44,7 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
                 <span class="tooltiptext"><?php esc_html_e('Select the type of the app.', 'dt-home') ?></span>
             </span>
         </td>
-        <td colspan="2">
+        <td colspan="3">
             <select style="min-width: 100%;" name="type" id="type" required onchange="toggleURLField()">
                 <option value=""><?php esc_html_e('Please select', 'dt-home') ?></option>
                 <option value="Web View"><?php esc_html_e('Web View', 'dt-home') ?></option>
@@ -58,7 +59,7 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
                 <span class="tooltiptext"><?php esc_html_e('Check this box to open the link in a new tab.', 'dt-home') ?></span>
             </span>
         </td>
-        <td colspan="2">
+        <td colspan="3">
             <input type="checkbox" name="open_in_new_tab" id="open_in_new_tab" value="1">
         </td>
     </tr>
@@ -82,7 +83,7 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
                 <span class="tooltiptext"><?php esc_html_e('Enter the URL for the app.', 'dt-home') ?></span>
             </span>
         </td>
-        <td colspan="2">
+        <td colspan="3">
             <input style="min-width: 100%;" type="text" name="url" id="url"/>
         </td>
     </tr>
@@ -92,7 +93,7 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
                 <span class="tooltiptext"><?php esc_html_e('Enter a slug for the app.', 'dt-home') ?></span>
             </span>
         </td>
-        <td colspan="2">
+        <td colspan="3">
             <input style="min-width: 100%;" type="text" name="slug" id="slug" pattern=".*\S+.*" title="<?php esc_attr_e('The name cannot be empty or just whitespace.', 'dt-home'); ?>" required/>
         </td>
     </tr>
@@ -102,7 +103,7 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
                 <span class="tooltiptext"><?php esc_html_e('Check this box to hide the app.', 'dt-home') ?></span>
             </span>
         </td>
-        <td colspan="2">
+        <td colspan="3">
             <input type="checkbox" name="is_hidden" id="is_hidden" value="1">
         </td>
     </tr>

--- a/resources/views/settings/edit.php
+++ b/resources/views/settings/edit.php
@@ -24,6 +24,7 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
         <th></th>
         <th></th>
         <th></th>
+        <th></th>
     </tr>
     </thead>
    <tbody>
@@ -33,7 +34,7 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
                 <span class="tooltiptext"><?php esc_html_e('Enter the name of the app.', 'dt-home') ?></span>
             </span>
         </td>
-        <td colspan="3">
+        <td colspan="4">
             <input style="min-width: 100%;" type="text" name="name" id="name" class="form-control"
                    pattern=".*\S+.*" title="<?php esc_attr_e('The name cannot be empty or just whitespace.', 'dt-home'); ?>"
                    value="<?php echo esc_attr($existing_data['name']); ?>" required>
@@ -45,7 +46,7 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
                 <span class="tooltiptext"><?php esc_html_e('Select the type of the app.', 'dt-home') ?></span>
             </span>
         </td>
-        <td colspan="3">
+        <td colspan="4">
             <select style="min-width: 100%;" id="type" name="type" required onchange="toggleURLField()">
                 <option value="" <?php echo empty($existing_data['type']) ? 'selected' : ''; ?>>
                     <?php esc_html_e('Please select', 'dt-home') ?>
@@ -66,7 +67,7 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
                 <span class="tooltiptext"><?php esc_html_e('Check this box to open the link in a new tab.', 'dt-home') ?></span>
             </span>
         </td>
-        <td colspan="2">
+        <td colspan="4">
             <input type="checkbox" name="open_in_new_tab" id="open_in_new_tab" value="1"
                 <?php checked($existing_data['open_in_new_tab'] ?? 0, 1); ?>>
         </td>
@@ -77,13 +78,13 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
                 <span class="tooltiptext"><?php esc_html_e('Upload an icon for the app.', 'dt-home') ?></span>
             </span>
         </td>
-        <td style="vertical-align: middle;">
+        <td style="vertical-align: middle; text-align: center; padding: 8px;">
             <?php if (!empty($existing_data['icon'])) : ?>
                 <?php if (filter_var($existing_data['icon'], FILTER_VALIDATE_URL) || strpos($existing_data['icon'], '/wp-content/') === 0) : ?>
                     <img src="<?php echo esc_url($existing_data['icon']); ?>" alt="<?php esc_attr_e('Icon', 'dt-home'); ?>"
-                         style="width: 50px; height: 50px;">
+                         style="width: 32px; height: 32px; object-fit: contain;">
                 <?php elseif (preg_match('/^mdi\smdi-/', $existing_data['icon'])) : ?>
-                    <i class="<?php echo esc_attr($existing_data['icon']); ?>" style="font-size: 50px;"></i>
+                    <i class="<?php echo esc_attr($existing_data['icon']); ?>" style="font-size: 32px;"></i>
                 <?php endif; ?>
             <?php endif; ?>
         </td>
@@ -107,7 +108,7 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
                     <span class="tooltiptext"><?php esc_html_e('Enter the URL for the app.', 'dt-home') ?></span>
                 </span>
             </td>
-            <td colspan="3">
+            <td colspan="4">
                 <input style="min-width: 100%;" type="text" name="url" id="url" class="form-control"
                        value="<?php echo esc_url(isset($existing_data['url']) ? $existing_data['url'] : ''); ?>">
             </td>
@@ -120,7 +121,7 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
                 <span class="tooltiptext"><?php esc_html_e('Enter a slug for the app.', 'dt-home') ?></span>
             </span>
         </td>
-        <td colspan="2">
+        <td colspan="4">
             <input style="min-width: 100%;" type="text" name="slug" id="slug" readonly
                    value="<?php echo esc_attr(isset($existing_data['slug']) ? $existing_data['slug'] : ''); ?>"
                    required/>
@@ -132,7 +133,7 @@ get_template_part('dt-core/admin/menu/tabs/dialog-icon-selector');
                 <span class="tooltiptext"><?php esc_html_e('Check this box to hide the app.', 'dt-home') ?></span>
             </span>
         </td>
-        <td colspan="3">
+        <td colspan="4">
             <input type="checkbox" name="is_hidden" id="is_hidden"
                    value="1" <?php checked($existing_data['is_hidden'], 1); ?>>
         </td>

--- a/routes/launcher.php
+++ b/routes/launcher.php
@@ -23,6 +23,7 @@ $r->group('/apps/launcher/{key}', function ( RouteCollectionInterface $r ) {
     $r->get( '/', [ LauncherController::class, 'show' ] );
     $r->get( '/training', [ TrainingController::class, 'show' ] );
     $r->get( '/logout', [ LoginController::class, 'logout' ] );
+    $r->get( '/reset-apps', [ AppController::class, 'reset_apps' ] );
 })->middleware( new LoggedIn() )
     ->middleware( new CheckShareCookie() );
 

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -26,6 +26,7 @@ $r->group( '/wp-admin', function ( RouteCollectionInterface $r ) {
 	$r->get( '/admin.php?page=dt_home&tab=app&action=delete/{slug}', [ AppSettingsController::class, 'delete' ] );
 	$r->get( '/admin.php?page=dt_home&tab=app&action=softdelete/{slug}', [ AppSettingsController::class, 'soft_delete_app' ] );
 	$r->get( '/admin.php?page=dt_home&tab=app&action=restore_app/{slug}', [ AppSettingsController::class, 'restore_app' ] );
+	$r->get( '/admin.php?page=dt_home&tab=app&action=reorder', [ AppSettingsController::class, 'reorder_get' ] );
 
 	$r->get( '/admin.php?page=dt_home&tab=training', [ TrainingSettingsController::class, 'show' ] );
 	$r->get('/admin.php?page=dt_home&tab=training&action=create', [
@@ -42,6 +43,7 @@ $r->group( '/wp-admin', function ( RouteCollectionInterface $r ) {
 		TrainingSettingsController::class,
 		'delete'
 	]);
+	$r->get( '/admin.php?page=dt_home&tab=training&action=reorder', [ TrainingSettingsController::class, 'reorder_get' ] );
 })->middleware( new HasCap( 'manage_dt' ) );
 
 $r->group( '/wp-admin', function ( RouteCollectionInterface $r ) {


### PR DESCRIPTION
- fixes: #312 
---

<img width="949" height="623" alt="Screenshot 2025-07-10 at 17 12 44" src="https://github.com/user-attachments/assets/7a992790-b4c5-4948-bb1e-1e9aabcbe6d2" />

## Notice

- Calling the `/apps/launcher/{key}/reset-apps` endpoint from the frontend browser, will manually force the reordered apps list to take effect.
- Reordered training videos should automatically update.