### PR TITLE
Create bottom nav for webview apps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,8 @@
     }
   ],
   "scripts": {
+    "lint": "vendor/bin/phpcs",
+    "lintfix": "vendor/bin/phpcbf",
     "pre-install-cmd": [
       "bin/setup-scoper.sh"
     ]

--- a/development.md
+++ b/development.md
@@ -2,12 +2,13 @@
 
 ## Locally
 
-Run 
-```
-npm run dev
-``` 
+- Copy source code to `/wp-content/plugins/dt-home/` on local site.
+- Within the site plugin directory (above):
+  - Run `composer install`
+  - Run `npm install`
+  - Run `npm run dev`
 
-while working locally.
+Note: If vendor-scoped folder is not generated or `composer install` always says php-scoped needs to be installed, make sure the [Composer bin folder is in your PATH](https://stackoverflow.com/a/64545124/92876).
 
 ## Packaging for production
 

--- a/resources/css/webview.css
+++ b/resources/css/webview.css
@@ -1,5 +1,130 @@
+body:has(.webview__container),
 .webview__container,
 .webview__container > iframe {
-    height: 100lvh;
-    width: 100lvw;
+    --launcher-bottom-nav-height: 60px;
+    --max-bottom-width: 800px;
+    height: 100%;
+    width: 100%;
+}
+
+.webview__container {
+    position: relative;
+    overflow: hidden;
+}
+
+.webview__container > iframe {
+    height: calc(100% - var(--launcher-bottom-nav-height));
+}
+
+.launcher-bottom-nav,
+.launcher-bottom-nav .nav-container {
+    height: var(--launcher-bottom-nav-height, 60px);
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-evenly;
+    background-color: var(--surface-0);
+}
+.launcher-bottom-nav {
+    position: absolute;
+    bottom: 0;
+    z-index: 5;
+    box-shadow: 0 0 4px 4px rgb(0 0 0 / 25%);
+
+    .nav-container {
+        max-width: var(--max-bottom-width);
+    }
+
+    button.nav-item {
+        background: none;
+        border: none;
+        padding: 0;
+        margin: 0;
+        &:hover { cursor: pointer; }
+    }
+    a.nav-item {
+        text-decoration: none;
+    }
+    .nav-item {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        font-size: 10px;
+        color: inherit;
+        i {
+            font-size: 30px;
+            height: 40px;
+        }
+    }
+
+    .nav-item-home {
+        background-color: var(--primary-color);
+        color: var(--text-color-inverse);
+        width: 60px;
+        height: 60px;
+        border-radius: 50%;
+        position: relative;
+        top: -1rem;
+        box-shadow: 0 0px 4px 4px rgb(0 0 0 / 25%);
+        i {
+            font-size: 40px;
+            height: 60px;
+        }
+    }
+}
+
+.launcher-apps-selector {
+    background-color: var(--surface-0);
+    padding-bottom: var(--launcher-bottom-nav-height);
+    position: absolute;
+    bottom: -40vh;
+    left: 0;
+    width: 100%;
+    z-index: 4;
+    transition: bottom 0.3s ease-in-out;
+    box-shadow: 0 0px 4px 4px rgb(0 0 0 / 25%);
+    max-height: 40vh;
+    overflow-y: auto;
+
+    &.open {
+        bottom: 0;
+    }
+
+    ul, li {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        width: fit-content;
+    }
+    ul {
+        margin: 0 auto;
+        max-width: var(--max-bottom-width);
+        padding-block: 1rem;
+        @media screen and (max-width: 800px) {
+            margin: 0;
+        }
+    }
+
+    li {
+        /*border-bottom: 1px solid var(--gray-1);*/
+        width: fit-content;
+        a {
+            text-decoration: none;
+            color: inherit;
+            display: inline-flex;
+            padding: 0.5rem 1rem;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        img {
+            height: 1.5rem;
+        }
+        i.mdi {
+            font-size: 1.5rem;
+        }
+    }
+
 }

--- a/resources/views/partials/launcher-bottom-nav.php
+++ b/resources/views/partials/launcher-bottom-nav.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @var array $apps
+ */
+use function DT\Home\magic_url;
+
+$filtered_apps = array_filter( $apps, function ( $app ) {
+    return $app['is_hidden'] !== true &&
+        isset($app['magic_link_meta']);
+})
+?>
+<script type="application/javascript">
+    function toggleAppsSelector() {
+        var selector = document.querySelector('.launcher-apps-selector');
+        selector.classList.toggle('open');
+    }
+</script>
+<div class="launcher-bottom-nav">
+    <div class="nav-container">
+        <button class="nav-item" onclick="toggleAppsSelector()">
+            <i class="mdi mdi-apps"></i>
+            <?php echo __( 'Apps', 'dt-home' ) ?>
+        </button>
+        <a href="<?php echo esc_url( magic_url( '' ) ); ?>" class="nav-item nav-item-home">
+            <i class="mdi mdi-home"></i>
+        </a>
+        <a href="<?php echo esc_url( magic_url( 'logout' ) ); ?>" class="nav-item">
+            <i class="mdi mdi-logout"></i>
+            <?php echo __( 'Log Out', 'dt-home' ) ?>
+        </a>
+    </div>
+</div>
+
+<div class="launcher-apps-selector">
+    <ul>
+    <?php foreach ( $filtered_apps as $app ): ?>
+        <li>
+            <a href="<?php echo esc_url( magic_url( 'app/' . $app['slug'] ) ); ?>">
+
+                <?php if (str_starts_with( $app['icon'], 'http') || str_starts_with( $app['icon'], '/' ) ): ?>
+                    <img src="<?php echo esc_url( $app['icon'] ); ?>" alt="<?php echo esc_attr( $app['name'] ) || 'Link'; ?>" />
+                <?php else: ?>
+                    <i class="<?php echo esc_attr( $app['icon'] ); ?>"
+                       aria-hidden="true"
+                    ></i>
+                <?php endif; ?>
+                <span class="name"><?php echo $app['name'] ?></span>
+            </a>
+            <span class="muted" style="display:none;"><?php print_r($app) ?></span>
+        </li>
+    <?php endforeach; ?>
+    </ul>
+</div>

--- a/resources/views/partials/launcher-bottom-nav.php
+++ b/resources/views/partials/launcher-bottom-nav.php
@@ -6,7 +6,7 @@ use function DT\Home\magic_url;
 
 $filtered_apps = array_filter( $apps, function ( $app ) {
     return $app['is_hidden'] !== true &&
-        isset($app['magic_link_meta']);
+        isset( $app['magic_link_meta'] );
 })
 ?>
 <script type="application/javascript">
@@ -19,14 +19,14 @@ $filtered_apps = array_filter( $apps, function ( $app ) {
     <div class="nav-container">
         <button class="nav-item" onclick="toggleAppsSelector()">
             <i class="mdi mdi-apps"></i>
-            <?php echo __( 'Apps', 'dt-home' ) ?>
+            <?php esc_html_e( 'Apps', 'dt-home' ) ?>
         </button>
         <a href="<?php echo esc_url( magic_url( '' ) ); ?>" class="nav-item nav-item-home">
             <i class="mdi mdi-home"></i>
         </a>
         <a href="<?php echo esc_url( magic_url( 'logout' ) ); ?>" class="nav-item">
             <i class="mdi mdi-logout"></i>
-            <?php echo __( 'Log Out', 'dt-home' ) ?>
+            <?php echo esc_html_e( 'Log Out', 'dt-home' ) ?>
         </a>
     </div>
 </div>
@@ -37,16 +37,16 @@ $filtered_apps = array_filter( $apps, function ( $app ) {
         <li>
             <a href="<?php echo esc_url( magic_url( 'app/' . $app['slug'] ) ); ?>">
 
-                <?php if (str_starts_with( $app['icon'], 'http') || str_starts_with( $app['icon'], '/' ) ): ?>
+                <?php if ( str_starts_with( $app['icon'], 'http' ) || str_starts_with( $app['icon'], '/' ) ): ?>
                     <img src="<?php echo esc_url( $app['icon'] ); ?>" alt="<?php echo esc_attr( $app['name'] ) || 'Link'; ?>" />
-                <?php else: ?>
+                <?php else : ?>
                     <i class="<?php echo esc_attr( $app['icon'] ); ?>"
                        aria-hidden="true"
                     ></i>
                 <?php endif; ?>
-                <span class="name"><?php echo $app['name'] ?></span>
+                <span class="name"><?php echo esc_html( $app['name'] ) ?></span>
             </a>
-            <span class="muted" style="display:none;"><?php print_r($app) ?></span>
+            <span class="muted" style="display:none;"><?php print_r( $app ) ?></span>
         </li>
     <?php endforeach; ?>
     </ul>

--- a/resources/views/web-view.php
+++ b/resources/views/web-view.php
@@ -2,6 +2,7 @@
 /**
  * @var array $app
  * @var string $url
+ * @var array $apps_array
  */
 $this->layout( 'layouts/web-view' );
 ?>
@@ -10,5 +11,5 @@ $this->layout( 'layouts/web-view' );
 <iframe src="<?php echo esc_url( $url ); ?>" width="100%" height="650" frameborder="0"></iframe>
 
 <?php
-$this->insert( 'partials/return-to-launcher-button' );
+$this->insert( 'partials/launcher-bottom-nav', ['apps' => $apps_array] );
 ?>

--- a/resources/views/web-view.php
+++ b/resources/views/web-view.php
@@ -11,5 +11,5 @@ $this->layout( 'layouts/web-view' );
 <iframe src="<?php echo esc_url( $url ); ?>" width="100%" height="650" frameborder="0"></iframe>
 
 <?php
-$this->insert( 'partials/launcher-bottom-nav', ['apps' => $apps_array] );
+$this->insert( 'partials/launcher-bottom-nav', [ 'apps' => $apps_array ] );
 ?>

--- a/src/Controllers/MagicLink/AppController.php
+++ b/src/Controllers/MagicLink/AppController.php
@@ -34,6 +34,7 @@ class AppController
         $slug = $params['slug'];
         $apps = container()->get( Apps::class );
         $user_id = get_current_user_id();
+        $apps_array = $apps->for_user( $user_id );
         $app  = $apps->find_for_user( $user_id, $slug );
 
         if ( ! $app ) {
@@ -70,7 +71,7 @@ class AppController
             return response( __( 'Not Found', 'dt-home' ), 404 );
         }
 
-        return template( 'web-view', compact( 'app', 'url' ) );
+        return template( 'web-view', compact( 'app', 'url', 'apps_array' ) );
     }//end show()
 
 


### PR DESCRIPTION
Adds a bottom nav on webview screens.

- fixes height/width overflow that was causing permanent scroll bars
- Link to home screen
- Link to Log Out
- Link to quick app switcher
  - Slides up list of all available apps (not hidden and have magic link meta - to match app grid logic)

<img width="1082" height="2402" alt="dtplayground local_apps_launcher_afbedb6078bcef7f7eee700aca612db4dd716d9dbc4c997729a280b6d923862c_app_1739866475__dt_home=true(Pixel 7)" src="https://github.com/user-attachments/assets/a371f83f-2aa8-4a52-8403-9268fe64ca9c" />
<img width="1082" height="2402" alt="dtplayground local_apps_launcher_afbedb6078bcef7f7eee700aca612db4dd716d9dbc4c997729a280b6d923862c_app_1739866475__dt_home=true(Pixel 7) (1)" src="https://github.com/user-attachments/assets/79b451b7-d0a6-47bc-925d-cacc8ab37e0a" />
